### PR TITLE
Use correct parameter name in utility functions

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -339,11 +339,11 @@ function mParticleStart(options as object, messagePort as object)
         end function,
         
         isString : function(input as object) as boolean
-            return input <> invalid and (LCase(type(input)) = "rostring" or LCase(type(item)) = "string")
+            return input <> invalid and (LCase(type(input)) = "rostring" or LCase(type(input)) = "string")
         end function,
         
         isArray : function(input as object) as boolean
-            return input <> invalid and (LCase(type(input)) = "roarray" or LCase(type(item)) = "array")
+            return input <> invalid and (LCase(type(input)) = "roarray" or LCase(type(input)) = "array")
         end function
     }
     


### PR DESCRIPTION
This addresses this issue: https://github.com/mParticle/mparticle-roku-sdk/issues/3

Likely not hit too often if the customer is using roString/roArray.