### PR TITLE
Add Identity and Attribute Change Messages

### DIFF
--- a/example-scenegraph-sdk/source/components/helloworld.brs
+++ b/example-scenegraph-sdk/source/components/helloworld.brs
@@ -16,7 +16,7 @@ sub init()
     identityApiRequest.userIdentities = {}
     identityApiRequest.userIdentities[mpConstants.IDENTITY_TYPE.OTHER] = "foo"
     m.mparticle.identity.modify(identityApiRequest)
-    dentityApiRequest = {}
+    identityApiRequest = {}
     identityApiRequest.userIdentities = {}
     identityApiRequest.userIdentities[mpConstants.IDENTITY_TYPE.OTHER] = "bar"
     m.mparticle.identity.modify(identityApiRequest)

--- a/example-scenegraph-sdk/source/components/helloworld.brs
+++ b/example-scenegraph-sdk/source/components/helloworld.brs
@@ -16,9 +16,15 @@ sub init()
     identityApiRequest.userIdentities = {}
     identityApiRequest.userIdentities[mpConstants.IDENTITY_TYPE.OTHER] = "foo"
     m.mparticle.identity.modify(identityApiRequest)
+    dentityApiRequest = {}
+    identityApiRequest.userIdentities = {}
+    identityApiRequest.userIdentities[mpConstants.IDENTITY_TYPE.OTHER] = "bar"
+    m.mparticle.identity.modify(identityApiRequest)
     m.mparticle.logEvent("hello world!")
-    m.mparticle.identity.setUserAttribute("example attribute key", "example attribute value")
+    m.mparticle.identity.setUserAttribute("example attribute key", "example attribute value 1")
     m.mparticle.identity.setUserAttribute("example attribute array", ["foo", "bar"])
+    m.mparticle.identity.setUserAttribute("example attribute key", "example attribute value 2")
+    m.mparticle.identity.setUserAttribute("example attribute array", ["noo", "mar"])
 
     m.mparticle.logScreenEvent("hello screen!")
 

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -701,11 +701,11 @@ function mParticleStart(options as object, messagePort as object)
 
             if (FormatJSON(attributeValue) <> FormatJSON(oldValue)) then
                 deleted = false
-                if (attributeValue = invalid or FormatJSON(attributeValue).len() = 0) then
+                if (mparticle()._internal.utils.isEmpty(attributeValue) or FormatJSON(attributeValue).len() = 0) then
                     deleted = true
                 end if
                 isNewAttribute = false
-                if (oldValue = invalid or FormatJSON(oldValue).len() = 0) then
+                if (mparticle()._internal.utils.isEmpty(oldValue) or FormatJSON(oldValue).len() = 0) then
                     isNewAttribute = true
                 end if
                 mparticle().logMessage(mparticle().model.UserAttributeChange(attributeKey, attributeValue, oldValue, deleted, isNewAttribute))
@@ -1347,8 +1347,6 @@ function mParticleStart(options as object, messagePort as object)
             message.ov = oldValue
             message.d = deleted
             message.na = isNewAttribute
-            currentMpid = mparticle()._internal.storage.getCurrentMpid()
-            message.ua = mparticle()._internal.storage.getUserAttributes(currentMpid)
 
             return message
         end function,
@@ -1357,9 +1355,6 @@ function mParticleStart(options as object, messagePort as object)
             message = m.Message(mParticleConstants().MESSAGE_TYPE.USER_IDENTITY_CHANGE)
             message.ni = newIdentity
             message.oi = oldIdentity
-            currentMpid = mparticle()._internal.storage.getCurrentMpid()
-            identities = mparticle()._internal.storage.getUserIdentities(currentMpid)
-            message.ui = identities
 
             return message
         end function,


### PR DESCRIPTION
# Summary

The Identity and Attribute Changed Message type and automated message were not previously implemented for Roku. This change ensures that if an Identity or Attribute is changed the Roku SDK automatically forward the change event to the mParticle server.
