### PR TITLE
Remove population of duid field

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -921,7 +921,6 @@ function mParticleStart(options as object, messagePort as object)
                     dp: "Roku",
                     dn: info.GetModelDisplayName(),
                     p: info.GetModel(),
-                    duid: info.GetChannelClientId(),
                     vr: info.GetVersion(),
                     rida: info.GetRIDA(),
                     lat: info.IsRIDADisabled(),


### PR DESCRIPTION
# Summary

This `duid` field was once a "multi-platform" field on ingress into mParticle, and would be translated to a different platform specific property on egress. This has long since changed, and this field now only represents the "android_id" field of the Events API. Roku needs to stop populating this field.