### PR TITLE
Fix isEmpty for arrays

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -593,7 +593,7 @@ function mParticleStart(options as object, messagePort as object)
                 return true
             else
                 if (LCase(type(input)) = "roarray" or LCase(type(input)) = "array")
-                    return input[0] = invalid
+                    return input.Count() = 0
                 end if
                 if (LCase(type(input)) = "rostring" or LCase(type(input)) = "string")
                     return Len(input) = 0

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -589,7 +589,17 @@ function mParticleStart(options as object, messagePort as object)
         end function,
 
         isEmpty: function(input as dynamic) as boolean
-            return input = invalid or len(input) = 0
+            if input = invalid
+                return true
+            else
+                if (LCase(type(input)) = "roarray" or LCase(type(input)) = "array")
+                    return input[0] = invalid
+                end if
+                if (LCase(type(input)) = "rostring" or LCase(type(input)) = "string")
+                    return Len(input) = 0
+                end if
+            end if
+            return false
         end function,
 
         isString: function(input as object) as boolean


### PR DESCRIPTION
# Summary

Our isEmpty function failed to handle array objects correctly after a recent update. This change ensures we handle each possible object appropriately. 
