### PR TITLE
Fixing the correct device info and variables

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -574,7 +574,7 @@ function mParticleStart(options as object, messagePort as object)
 
     mpUtils = {
         currentChannelVersion: function() as string
-            info = CreateObject("roAppInfo")
+            info = CreateObject("roDeviceInfo")
             osVersion = info.GetOSVersion()
             return osVersion["major"] + "." + osVersion["minor"]
         end function,
@@ -903,7 +903,7 @@ function mParticleStart(options as object, messagePort as object)
                 appInfo = CreateObject("roAppInfo")
                 deviceInfo = CreateObject("roDeviceInfo")
                 env = 2
-                osVersion = info.GetOSVersion()
+                osVersion = deviceInfo.GetOSVersion()
                 if (mparticle()._internal.configuration.development) then
                     env = 1
                 end if


### PR DESCRIPTION
## Summary
The newest version of Roku SDK was crashing due to lines 577 and 906, were in both lines GetOSVersion() were not being used on device info and were used on either app info or a null variable. The fix here is to change those variable to device info.

## Testing Plan
Events were being uploaded after the fix and the Roku app wasn't crashing.