### PR TITLE
fix: app version fix instead of os version

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -1007,7 +1007,7 @@ function mParticleStart(options as object, messagePort as object)
                 end if
                 m.collectedApplicationInfo = {
                     an: appInfo.GetTitle(),
-                    av: osVersion["major"] + "." + osVersion["minor"],
+                    av: appInfo.getVersion(),
                     apn: appInfo.GetID(),
                     abn: appInfo.GetValue("build_version"),
                     env: env


### PR DESCRIPTION
 ## Summary
 - {provide a thorough description of the changes}
Customer raised issue that appversion was being assigned as Roku OS version instead of app version. I was able to reproduce behavior and after further investigation of roku code, I noticed that we were assigning `av` as `osVersion["major"] + "." + osVersion["minor"]` . 

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}
E2E testing was done locally in sample roku app and verified that fix is working. 

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Jira filed: https://mparticle-eng.atlassian.net/browse/PRODRDMP-5697
