### PR TITLE
Feature:expose session info as scenegraph node

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -34,7 +34,8 @@ function mParticleConstants() as object
     SCENEGRAPH_NODES = {
         API_CALL_NODE: "mParticleApiCall",
         CURRENT_USER_NODE: "mParticleCurrentUser",
-        IDENTITY_RESULT_NODE: "mParticleIdentityResult"
+        IDENTITY_RESULT_NODE: "mParticleIdentityResult",
+        CURRENT_SESSION_NODE: "mParticleCurrentSession"
     }
     USER_ATTRIBUTES = {
         FIRSTNAME: "$FirstName",

--- a/mParticleTask.brs
+++ b/mParticleTask.brs
@@ -16,6 +16,7 @@ sub setupRunLoop()
     mParticleStart(options, m.port)
     m.mparticle = mparticle()
     m.top[mParticleConstants().SCENEGRAPH_NODES.CURRENT_USER_NODE] = m.mparticle.identity.getCurrentUser()
+    m.top[mParticleConstants().SCENEGRAPH_NODES.CURRENT_SESSION_NODE] = m.mparticle._internal.sessionManager.getCurrentSession()
     while true
         msg = wait(15 * 1000, m.port)
         if (msg = invalid) then

--- a/mParticleTask.xml
+++ b/mParticleTask.xml
@@ -4,6 +4,7 @@
   	<field id="mParticleApiCall" type="assocarray"/>
   	<field id="mParticleIdentityResult" type="assocarray"/>
   	<field id="mParticleCurrentUser" type="assocarray"/>
+    <field id="mParticleCurrentSession" type="assocarray"/>
   </interface>
   <!-- Replace with correct path if necessary -->
   <script type="text/brightscript" uri="pkg:/components/mParticleTask.brs"/>


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - We have a GAP request by multiple clients to expose the session info including the sessionId to match the other SDKs

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - added the coded locally to my Roku project and was able to view the session information as a scenegraph node.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
