### PR TITLE
feat: Add Media Session Timestamps and Media Sessions time tracking

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -1864,10 +1864,7 @@ function mParticleStart(options as object, messagePort as object)
                 end if
                 if (mediaSession.mediaContentTimeSpent <> invalid) then
                     if (mediaSession.currentPlaybackStartTimestamp > 0) then
-                        date = CreateObject("roDateTime")
-                        currentTime = CreateObject("roLongInteger")
-                        currentTime.SetLongInt(date.asSeconds())
-                        currentUnixTimeStamp = (currentTime * 1000) + date.getMilliseconds()
+                        currentUnixTimeStamp = mparticle()._internal.utils.unixTimeMillis()
                         mediaSession.mediaContentTimeSpent = mediaSession.storedPlaybackTime + (currentUnixTimeStamp - mediaSession.currentPlaybackStartTimestamp)
                     else 
                         mediaSession.mediaContentTimeSpent = mediaSession.storedPlaybackTime

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -1866,7 +1866,7 @@ function mParticleStart(options as object, messagePort as object)
                     if (mediaSession.currentPlaybackStartTimestamp > 0) then
                         currentUnixTimeStamp = mparticle()._internal.utils.unixTimeMillis()
                         mediaSession.mediaContentTimeSpent = mediaSession.storedPlaybackTime + (currentUnixTimeStamp - mediaSession.currentPlaybackStartTimestamp)
-                    else 
+                    else
                         mediaSession.mediaContentTimeSpent = mediaSession.storedPlaybackTime
                     end if
                     eventAttributes.media_content_time_spent = mediaSession.mediaContentTimeSpent.ToStr()
@@ -2207,7 +2207,7 @@ function mParticleSGBridge(task as object) as object
             end function,
             logMediaContentEnd: function(mediaSession as object, options = {} as object) as void
                 mediaSession.mediaContentComplete = true
-                if (mediaSession.currentPlaybackStartTimestamp > 0) then 
+                if (mediaSession.currentPlaybackStartTimestamp > 0) then
                     mediaSession.storedPlaybackTime = mediaSession.storedPlaybackTime + (m.unixTimeMillis() - mediaSession.currentPlaybackStartTimestamp)
                     mediaSession.currentPlaybackStartTimestamp = 0
                 end if
@@ -2220,7 +2220,7 @@ function mParticleSGBridge(task as object) as object
                 m.invokeFunction("media/logPlay", [mediaSession, options])
             end function,
             logPause: function(mediaSession as object, options = {} as object) as void
-                if (mediaSession.currentPlaybackStartTimestamp > 0) then 
+                if (mediaSession.currentPlaybackStartTimestamp > 0) then
                     mediaSession.storedPlaybackTime = mediaSession.storedPlaybackTime + (m.unixTimeMillis() - mediaSession.currentPlaybackStartTimestamp)
                     mediaSession.currentPlaybackStartTimestamp = 0
                 end if
@@ -2286,7 +2286,7 @@ function mParticleSGBridge(task as object) as object
             invokeFunction: function(name as string, args)
                 if (args[0].mediaSessionEndTime) then
                     args[0].mediaSessionEndTime = m.unixTimeMillis()
-                endif
+                end if
                 invocation = {}
                 invocation.methodName = name
                 invocation.args = args

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -426,7 +426,11 @@ function mParticleConstants() as object
             session.mediaSessionId = CreateObject("roDeviceInfo").GetRandomUUID()
             session.currentPlayheadPosition = 0
             session.mediaContentComplete = false
+            session.currentPlaybackStartTimestamp = 0
+            session.storedPlaybackTime = 0
             session.mediaContentTimeSpent = 0
+            session.mediaSessionStartTime = m.unixTimeMillis()
+            session.mediaSessionEndTime = m.unixTimeMillis()
             session.mediaSessionSegmentTotal = 0
             session.mediaSessionAdTotal = 0
             session.mediaTotalAdTimeSpent = 0
@@ -475,6 +479,12 @@ function mParticleConstants() as object
         end function,
         setMediaSessionAdObjects: function(session as object, mediaSessionAdObjects as object)
             session.mediaSessionAdObjects = mediaSessionAdObjects
+        end function,
+        unixTimeMillis: function() as longinteger
+            date = CreateObject("roDateTime")
+            currentTime = CreateObject("roLongInteger")
+            currentTime.SetLongInt(date.asSeconds())
+            return (currentTime * 1000) + date.getMilliseconds()
         end function
     }
 
@@ -1853,6 +1863,15 @@ function mParticleStart(options as object, messagePort as object)
                     eventAttributes.media_content_complete = "false"
                 end if
                 if (mediaSession.mediaContentTimeSpent <> invalid) then
+                    if (mediaSession.currentPlaybackStartTimestamp > 0) then
+                        date = CreateObject("roDateTime")
+                        currentTime = CreateObject("roLongInteger")
+                        currentTime.SetLongInt(date.asSeconds())
+                        currentUnixTimeStamp = (currentTime * 1000) + date.getMilliseconds()
+                        mediaSession.mediaContentTimeSpent = mediaSession.storedPlaybackTime + (currentUnixTimeStamp - mediaSession.currentPlaybackStartTimestamp)
+                    else 
+                        mediaSession.mediaContentTimeSpent = mediaSession.storedPlaybackTime
+                    end if
                     eventAttributes.media_content_time_spent = mediaSession.mediaContentTimeSpent.ToStr()
                 end if
                 eventAttributes.media_session_segment_total = mediaSession.mediaSessionSegmentTotal.ToStr()
@@ -2190,12 +2209,24 @@ function mParticleSGBridge(task as object) as object
                 m.invokeFunction("media/logMediaSessionSummary", [mediaSession, options])
             end function,
             logMediaContentEnd: function(mediaSession as object, options = {} as object) as void
+                mediaSession.mediaContentComplete = true
+                if (mediaSession.currentPlaybackStartTimestamp > 0) then 
+                    mediaSession.storedPlaybackTime = mediaSession.storedPlaybackTime + (m.unixTimeMillis() - mediaSession.currentPlaybackStartTimestamp)
+                    mediaSession.currentPlaybackStartTimestamp = 0
+                end if
                 m.invokeFunction("media/logMediaContentEnd", [mediaSession, options])
             end function,
             logPlay: function(mediaSession as object, options = {} as object) as void
+                if (mediaSession.currentPlaybackStartTimestamp = 0) then
+                    mediaSession.currentPlaybackStartTimestamp = m.unixTimeMillis()
+                end if
                 m.invokeFunction("media/logPlay", [mediaSession, options])
             end function,
             logPause: function(mediaSession as object, options = {} as object) as void
+                if (mediaSession.currentPlaybackStartTimestamp > 0) then 
+                    mediaSession.storedPlaybackTime = mediaSession.storedPlaybackTime + (m.unixTimeMillis() - mediaSession.currentPlaybackStartTimestamp)
+                    mediaSession.currentPlaybackStartTimestamp = 0
+                end if
                 m.invokeFunction("media/logPause", [mediaSession, options])
             end function,
             logSeekStart: function(mediaSession as object, position as double, options = {} as object) as void
@@ -2249,7 +2280,16 @@ function mParticleSGBridge(task as object) as object
             logQoS: function(mediaSession as object, startupTime as integer, droppedFrames as integer, bitRate as integer, fps as integer, options = {} as object) as void
                 m.invokeFunction("media/logQoS", [mediaSession, startupTime, droppedFrames, bitRate, fps, options])
             end function,
+            unixTimeMillis: function() as longinteger
+                date = CreateObject("roDateTime")
+                currentTime = CreateObject("roLongInteger")
+                currentTime.SetLongInt(date.asSeconds())
+                return (currentTime * 1000) + date.getMilliseconds()
+            end function,
             invokeFunction: function(name as string, args)
+                if (args[0].mediaSessionEndTime) then
+                    args[0].mediaSessionEndTime = m.unixTimeMillis()
+                endif
                 invocation = {}
                 invocation.methodName = name
                 invocation.args = args


### PR DESCRIPTION
 ## Summary
Added the following to Roku SDK's Media API
 - initializing and calculating the mediaSessionStartTime and mediaSessionEndTime
 - added storedPlaybackTime and currentPlaybackStartTimestamp
 - update the mediaSessionEndTime on every media session event logged (similar to Web, Android and iOS media SDKs)
 - update mediaContentComplete to true when logMediaContentEnd is called
 - calculating the mediaContentTimeSpent when logPause and logMediaContentEnd are called

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E tested
 - Before fix: 
<img width="1270" alt="Screenshot 2025-05-16 at 10 49 57 AM" src="https://github.com/user-attachments/assets/1d996313-9423-4cdb-9eac-42bb7b60a5eb" />
- After fix: 
<img width="1260" alt="Screenshot 2025-05-16 at 10 50 14 AM" src="https://github.com/user-attachments/assets/2ae35368-7605-4e81-aa0e-35beea4f82f0" />


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7260
