### PR TITLE
feat: Add Media Session custom attributes

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -1843,7 +1843,7 @@ function mParticleStart(options as object, messagePort as object)
                     for each attributeKey in attributeKeys
                         if (mputils.isString(mediaSessionAttributes[attributeKey])) then
                             eventAttributes[attributeKey] = mediaSessionAttributes[attributeKey]
-                        else 
+                        else
                             eventAttributes[attributeKey] = mediaSessionAttributes[attributeKey].ToStr()
                         end if
                     end for

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -416,13 +416,14 @@ function mParticleConstants() as object
     '
 
     MediaSession = {
-        build: function(contentId as string, title as string, contentType as string, streamType as string, duration = 0 as integer)
+        build: function(contentId as string, title as string, contentType as string, streamType as string, duration = 0 as integer, mediaSessionAttributes = {} as object)
             session = {}
             session.contentId = contentId
             session.title = title
             session.duration = duration
             session.contentType = contentType
             session.streamType = streamType
+            session.mediaSessionAttributes = mediaSessionAttributes
             session.mediaSessionId = CreateObject("roDeviceInfo").GetRandomUUID()
             session.currentPlayheadPosition = 0
             session.mediaContentComplete = false
@@ -436,6 +437,9 @@ function mParticleConstants() as object
         end function,
         setDuration: function(session as object, duration as integer)
             session.duration = duration
+        end function,
+        setMediaSessionAttributes: function(session as object, mediaSessionAttributes as object)
+            session.mediaSessionAttributes = mediaSessionAttributes
         end function,
         setCurrentPlayheadPosition: function(session as object, playheadPosition as integer)
             session.currentPlayheadPosition = playheadPosition
@@ -1831,6 +1835,17 @@ function mParticleStart(options as object, messagePort as object)
                         eventAttributes.segment_duration = mediaSession.segment.duration.ToStr()
                     end if
                 end if
+
+                if (mediaSession.mediaSessionAttributes.count() > 0) then
+                    mputils = mparticle()._internal.utils
+                    mediaSessionAttributes = mediaSession.mediaSessionAttributes
+                    attributeKeys = mediaSessionAttributes.Keys()
+                    for each attributeKey in attributeKeys
+                        if (mputils.isString(mediaSessionAttributes[attributeKey])) then
+                            eventAttributes[attributeKey] = mediaSessionAttributes[attributeKey]
+                        end if
+                    end for
+                endif
             end if
 
             return eventAttributes

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -1843,9 +1843,11 @@ function mParticleStart(options as object, messagePort as object)
                     for each attributeKey in attributeKeys
                         if (mputils.isString(mediaSessionAttributes[attributeKey])) then
                             eventAttributes[attributeKey] = mediaSessionAttributes[attributeKey]
+                        else 
+                            eventAttributes[attributeKey] = mediaSessionAttributes[attributeKey].ToStr()
                         end if
                     end for
-                endif
+                end if
             end if
 
             return eventAttributes


### PR DESCRIPTION
 ## Summary
 - The Media SDKs on all other platforms (Web, iOS and Android) have the capabilities of having media session attributes that get forwarded with every event within the media session and this PR is to add that capability to the Roku SDK as well.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E tested
 - Can be added as a parameter when initiating a mediaSession:     
 - `mediaSession = mpConstants.MediaSession.build("ABC123", "Space Pilot 3000", mparticleConstants().MEDIA_CONTENT_TYPE.VIDEO, mparticleConstants().MEDIA_STREAM_TYPE.LIVE_STREAM, 1800000, {"testMediaSeshAttr": "testValMedia"})`
- <img width="790" alt="Screenshot 2025-05-19 at 2 02 24 PM" src="https://github.com/user-attachments/assets/b7923c81-0760-4eae-88b3-fcda3b29a7a0" />
- <img width="779" alt="Screenshot 2025-05-19 at 2 03 04 PM" src="https://github.com/user-attachments/assets/5648d2dd-5fb9-4bef-b985-c76db6bde53c" />
- <img width="770" alt="Screenshot 2025-05-19 at 2 03 24 PM" src="https://github.com/user-attachments/assets/1bef020f-3b30-4417-88f7-4efc79ab275b" />
- <img width="778" alt="Screenshot 2025-05-19 at 2 03 45 PM" src="https://github.com/user-attachments/assets/ee36b697-6ede-4ad3-8930-2f691eedb57e" />
- <img width="779" alt="Screenshot 2025-05-19 at 2 04 04 PM" src="https://github.com/user-attachments/assets/385b0e70-d264-4be3-95a0-06978a2012ee" />
- Can also be added after initiating a mediaSession:
- `mediaSession = mpConstants.MediaSession.build("ABC123", "Space Pilot 3000", mparticleConstants().MEDIA_CONTENT_TYPE.VIDEO, mparticleConstants().MEDIA_STREAM_TYPE.LIVE_STREAM, 1800000)`
- `mediaSession.mediaSessionAttributes = {"testMediaAttr2": "testVal2"}`
- <img width="774" alt="Screenshot 2025-05-19 at 2 05 41 PM" src="https://github.com/user-attachments/assets/db8c5af9-818f-4eeb-860f-3fd63651f6fc" />
- <img width="772" alt="Screenshot 2025-05-19 at 2 06 10 PM" src="https://github.com/user-attachments/assets/1ee7c520-e573-4f77-a1e5-869d2d050115" />
- <img width="772" alt="Screenshot 2025-05-19 at 2 06 27 PM" src="https://github.com/user-attachments/assets/656bf556-3d96-4ddf-a0e1-5fe724640ca0" />
- <img width="778" alt="Screenshot 2025-05-19 at 2 06 44 PM" src="https://github.com/user-attachments/assets/67cb72c1-00e1-4164-95f3-cda0b1039d62" />
- <img width="774" alt="Screenshot 2025-05-19 at 2 07 04 PM" src="https://github.com/user-attachments/assets/f662120e-e83f-4450-b4a2-75f48b4d6767" />



 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7306
