### PR TITLE
feat: Calculate mediaTimeSpent based on current time

### DIFF
--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -2294,6 +2294,9 @@ function mParticleSGBridge(task as object) as object
             logQoS: function(mediaSession as object, startupTime as integer, droppedFrames as integer, bitRate as integer, fps as integer, options = {} as object) as void
                 m.invokeFunction("media/logQoS", [mediaSession, startupTime, droppedFrames, bitRate, fps, options])
             end function,
+            getMediaTimeSpent: function(mediaSession as object) as longinteger
+                return m.unixTimeMillis() - mediaSession.mediaSessionStartTime
+            end function,
             unixTimeMillis: function() as longinteger
                 date = CreateObject("roDateTime")
                 currentTime = CreateObject("roLongInteger")


### PR DESCRIPTION
 ## Summary
 - A customer noticed that the getter for mediaTimeSpent calculates the value based on the difference between mediaSessionEndTimestamp and mediaSessionStartTimestamp, which leads to inaccuracy since mediaSessionEndTimestamp is only updated when logging a media event, with this PR it now calculates based on on the difference between m.unixTimeMillis (internal function for current time) and mediaSessionStartTimestamp
 - BrightScript does not support property getters like some object-oriented languages (e.g., Javascript, Kotlin and Swift), therefore a getter function on it's own was implemented on the mpCreateSGBridgeMediaApi level and to invoke it would be the same way we invoke other media functions such as logPlay(), logPause(), etc...
 `m.mparticle.media.getMediaTimeSpent(mediaSession)`

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E tested
 - Assigned as a custom attribute between media events i,e: `customAttributes = { "Source": "Auto Playback", "testMediaTimeSpent": m.mparticle.media.getMediaTimeSpent(mediaSession).ToStr() }`
and results are below:
<img width="764" alt="Screenshot 2025-07-02 at 9 41 20 AM" src="https://github.com/user-attachments/assets/cc0a3b6c-66d4-49fe-a030-f381959f77cc" />
<img width="788" alt="Screenshot 2025-07-02 at 9 41 11 AM" src="https://github.com/user-attachments/assets/c887e8fd-8bc7-4d5e-a176-92c6df2e4b9b" />
<img width="764" alt="Screenshot 2025-07-02 at 9 41 39 AM" src="https://github.com/user-attachments/assets/6a82ba91-1859-44c4-a1a0-cf97d55d100d" />

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7275
