### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mParticle/sdk-team


### PR DESCRIPTION
## Background

- Ensures all PRs are automatically assigned to the SDK team for review

## What Has Changed

- Added `.github/CODEOWNERS` file assigning all files to @mParticle/sdk-team

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes NO-JIRA