### PR TITLE
refactor: getMediaTimeSpent invalid checks

### DIFF
--- a/example-scenegraph-sdk/source/tests/BasicsTests.spec.bs
+++ b/example-scenegraph-sdk/source/tests/BasicsTests.spec.bs
@@ -353,6 +353,27 @@ namespace tests
             m.assertEqual(mediaSession.playbackState, "pausedByUser")
         end function
 
+        @it("getCurrentMediaTimeSpent returns 0 for invalid inputs")
+        function _()
+            ' Test that getCurrentMediaTimeSpent handles invalid inputs gracefully
+            mpConstants = mparticleConstants()
+
+            ' Test 1: Invalid mediaSession should return 0
+            timeSpent = m.mp.media.getCurrentMediaTimeSpent(invalid)
+            m.assertEqual(timeSpent, 0, "getCurrentMediaTimeSpent should return 0 for invalid mediaSession")
+
+            ' Test 2: Valid mediaSession but invalid mediaSessionStartTime should return 0
+            mediaSession = mpConstants.MediaSession.build("test-id-4", "Test Content 4", mpConstants.MEDIA_CONTENT_TYPE.VIDEO, mpConstants.MEDIA_STREAM_TYPE.ON_DEMAND, 180000)
+            mediaSession.mediaSessionStartTime = invalid
+            timeSpent = m.mp.media.getCurrentMediaTimeSpent(mediaSession)
+            m.assertEqual(timeSpent, 0, "getCurrentMediaTimeSpent should return 0 for invalid mediaSessionStartTime")
+
+            ' Test 3: Valid mediaSession with valid mediaSessionStartTime should return time difference
+            mediaSession.mediaSessionStartTime = m.mp.media.unixTimeMillis()
+            timeSpent = m.mp.media.getCurrentMediaTimeSpent(mediaSession)
+            m.assertTrue(timeSpent >= 0, "getCurrentMediaTimeSpent should return a non-negative value for valid session")
+        end function
+
     end class
 end namespace
 

--- a/example-scenegraph-sdk/source/tests/BasicsTests.spec.bs
+++ b/example-scenegraph-sdk/source/tests/BasicsTests.spec.bs
@@ -360,13 +360,13 @@ namespace tests
 
             ' Test 1: Invalid mediaSession should return 0
             timeSpent = m.mp.media.getCurrentMediaTimeSpent(invalid)
-            m.assertEqual(timeSpent, 0, "getCurrentMediaTimeSpent should return 0 for invalid mediaSession")
+            m.assertEqual(timeSpent, 0&, "getCurrentMediaTimeSpent should return 0 for invalid mediaSession")
 
             ' Test 2: Valid mediaSession but invalid mediaSessionStartTime should return 0
             mediaSession = mpConstants.MediaSession.build("test-id-4", "Test Content 4", mpConstants.MEDIA_CONTENT_TYPE.VIDEO, mpConstants.MEDIA_STREAM_TYPE.ON_DEMAND, 180000)
             mediaSession.mediaSessionStartTime = invalid
             timeSpent = m.mp.media.getCurrentMediaTimeSpent(mediaSession)
-            m.assertEqual(timeSpent, 0, "getCurrentMediaTimeSpent should return 0 for invalid mediaSessionStartTime")
+            m.assertEqual(timeSpent, 0&, "getCurrentMediaTimeSpent should return 0 for invalid mediaSessionStartTime")
 
             ' Test 3: Valid mediaSession with valid mediaSessionStartTime should return time difference
             mediaSession.mediaSessionStartTime = m.mp.media.unixTimeMillis()

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -2310,7 +2310,7 @@ function mParticleSGBridge(task as object) as object
                 m.invokeFunction("media/logQoS", [mediaSession, startupTime, droppedFrames, bitRate, fps, options])
             end function,
             getCurrentMediaTimeSpent: function(mediaSession as object) as longinteger
-                if (mediaSession = invalid OR mediaSession.mediaSessionStartTime = invalid) then
+                if (mediaSession = invalid or mediaSession.mediaSessionStartTime = invalid) then
                     return 0
                 end if
                 return m.unixTimeMillis() - mediaSession.mediaSessionStartTime

--- a/mParticleCore.brs
+++ b/mParticleCore.brs
@@ -2309,7 +2309,10 @@ function mParticleSGBridge(task as object) as object
             logQoS: function(mediaSession as object, startupTime as integer, droppedFrames as integer, bitRate as integer, fps as integer, options = {} as object) as void
                 m.invokeFunction("media/logQoS", [mediaSession, startupTime, droppedFrames, bitRate, fps, options])
             end function,
-            getMediaTimeSpent: function(mediaSession as object) as longinteger
+            getCurrentMediaTimeSpent: function(mediaSession as object) as longinteger
+                if (mediaSession = invalid OR mediaSession.mediaSessionStartTime = invalid) then
+                    return 0
+                end if
                 return m.unixTimeMillis() - mediaSession.mediaSessionStartTime
             end function,
             unixTimeMillis: function() as longinteger


### PR DESCRIPTION
## Background
- The getMediaTimeSpent function lacked validation checks and could crash if called with invalid parameters.

## What Has Changed
- Renamed function to getCurrentMediaTimeSpent for clarity
- Added validation to check if mediaSession or mediaSessionStartTime is invalid
- Returns 0 when validation fails instead of causing runtime errors

## Screenshots/Video
<img width="206" height="216" alt="image" src="https://github.com/user-attachments/assets/d55ea58a-7a2a-45b6-b294-05bd3f22844b" />

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- Closes https://go/j/[SDKE-822]  
